### PR TITLE
Display related pull requests in an issue's detail view

### DIFF
--- a/app/views/issues/_pull_relations.html.erb
+++ b/app/views/issues/_pull_relations.html.erb
@@ -1,0 +1,21 @@
+<% if issue.pulls.present? %>
+  <hr>
+
+  <div id="pull_relations">
+    <p><strong><%=l(:label_pulls)%></strong></p>
+
+    <table class="list pulls odd-even">
+      <tbody>
+        <% issue.pulls.each do |pull| %>
+          <tr class="<%= pull.css_classes %>">
+            <td class="subject">
+              <a href="<%= pull_path(pull) %>">PR#<%= pull.id %></a>:
+              <%= pull.subject %>
+            </td>
+            <td class="status"><%= pull.status_label %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/assets/stylesheets/pulls.css
+++ b/assets/stylesheets/pulls.css
@@ -131,3 +131,7 @@ a.pull__commit:hover {
 .pulls__merge :last-child {
   margin-bottom: 0;
 }
+
+#pull_relations table.pulls {
+  border: 0;
+}

--- a/lib/redmine_pulls.rb
+++ b/lib/redmine_pulls.rb
@@ -1,8 +1,10 @@
 require 'redmine_pulls/hooks/views_layouts_hook'
+require 'redmine_pulls/hooks/display_related_pulls_in_issues'
 
 require 'redmine_pulls/patches/adapters/abstract_adapter_helper'
 require 'redmine_pulls/patches/adapters/git_adapter_helper'
 require 'redmine_pulls/patches/application_helper_patch'
+require 'redmine_pulls/patches/issue_patch'
 require 'redmine_pulls/patches/journal_patch'
 require 'redmine_pulls/patches/mailer_patch'
 require 'redmine_pulls/patches/notifiable_patch'

--- a/lib/redmine_pulls/hooks/display_related_pulls_in_issues.rb
+++ b/lib/redmine_pulls/hooks/display_related_pulls_in_issues.rb
@@ -1,0 +1,7 @@
+module RedminePulls
+  module Hooks
+    class DisplayRelatedPullsInIssues < Redmine::Hook::ViewListener
+      render_on :view_issues_show_description_bottom, :partial => 'issues/pull_relations'
+    end
+  end
+end

--- a/lib/redmine_pulls/patches/issue_patch.rb
+++ b/lib/redmine_pulls/patches/issue_patch.rb
@@ -1,0 +1,25 @@
+require_dependency 'issue'
+
+module RedminePulls
+  module Patches
+    module IssuePatch
+      def self.included(base) # :nodoc:
+        base.send(:include, InstanceMethods)
+
+        base.class_eval do
+          unloadable # Send unloadable so it will not be unloaded in development
+
+          has_and_belongs_to_many :pulls, :join_table => 'pull_issues', :readonly => true
+        end
+      end
+
+      module InstanceMethods
+        #
+      end
+    end
+  end
+end
+
+unless Issue.included_modules.include?(RedminePulls::Patches::IssuePatch)
+  Issue.send(:include, RedminePulls::Patches::IssuePatch)
+end

--- a/test/fixtures/pull_issues.yml
+++ b/test/fixtures/pull_issues.yml
@@ -1,0 +1,4 @@
+pull_issue_001:
+  id: 1
+  pull_id: 1
+  issue_id: 1

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -1,0 +1,53 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class IssuesControllerTest < ActionController::TestCase
+  fixtures :projects,
+           :users, :email_addresses, :user_preferences,
+           :roles,
+           :members,
+           :member_roles,
+           :issues,
+           :issue_statuses,
+           :issue_relations,
+           :versions,
+           :trackers,
+           :projects_trackers,
+           :issue_categories,
+           :enabled_modules,
+           :enumerations,
+           :attachments,
+           :workflows,
+           :custom_fields,
+           :custom_values,
+           :custom_fields_projects,
+           :custom_fields_trackers,
+           :time_entries,
+           :journals,
+           :journal_details,
+           :queries,
+           :repositories,
+           :changesets,
+           :issues,
+           :pulls,
+           :pull_issues
+
+  def setup
+    @project = Project.find(1)
+    EnabledModule.create(:project => @project, :name => 'pulls')
+    @request.session[:user_id] = 1
+  end
+
+  def test_get_show_with_related_pull
+    get :show, :id => 1
+
+    assert_response :success
+    assert_select '#pull_relations a', :text => /PR#1/
+  end
+
+  def test_get_show_without_related_pull
+    get :show, :id => 2
+
+    assert_response :success
+    assert_select '#pull_relations', 0
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,4 @@ end
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
 
 # Enable project fixtures
-ActiveRecord::FixtureSet.create_fixtures(File.dirname(__FILE__) + '/fixtures/', [:pulls])
+ActiveRecord::FixtureSet.create_fixtures(File.dirname(__FILE__) + '/fixtures/', [:pulls, :pull_issues])


### PR DESCRIPTION
# Description

This pull request add a list of related pull requests the detail view of an issue. The result looks like this:

![Screen Shot 2019-06-19 at 11 13 45](https://user-images.githubusercontent.com/1497697/59777819-53741b80-9283-11e9-8927-6a6e77e52d0e.png)

Related pull requests is read-only and the section is completely hidden if there is not related PRs.

Fixes # 40

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests have been added on the IssueController to validate that the section is displayed correctly.

**Test Configuration**:
* Firmware version: ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-darwin18]
* Hardware: macOS 10.14.5 Mojave
* Toolchain: Redmine 3.4.5.stable
* SDK: Rails 4.2.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
