### PR TITLE
Adjust side by side diff views to make sure they are aligned

### DIFF
--- a/assets/stylesheets/pulls.css
+++ b/assets/stylesheets/pulls.css
@@ -40,8 +40,17 @@ span.search_for_reviewers {
   white-space: nowrap;
 }
 
-.pulls__changes .line-code {
+.pulls__changes table.filecontent th.line-num {
+  vertical-align: top;
+}
+
+.pulls__changes table.filecontent td.line-code:nth-child(2),
+.pulls__changes table.filecontent td.line-code:nth-child(4) {
   width: 48%;
+}
+
+.pulls__changes table.filecontent td.line-code pre {
+  word-break: break-word;
 }
 
 .pulls__status {


### PR DESCRIPTION
# Description

In order to facilitate reviews, this PR make sure that columns always takes a maximum of 50% of the screen size when the diff is in side by side mode.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It was only manually tested on macOS.

**Test Configuration**:
* Firmware version: ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-darwin18]
* Hardware: macOS 10.14.5 Mojave
* Toolchain: Redmine 3.4.5.stable
* SDK: Rails 4.2.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
