### PR TITLE
Update Redmine tested versions to the latest in the 3.4.x serie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ rvm:
 cache: bundler
 
 env:
-  - REDMINE_VER=3.4.7 DB=mysql CC_COVERAGE=true
-  - REDMINE_VER=3.4.7 DB=postgresql
+  - REDMINE_VER=3.4.11 DB=mysql CC_COVERAGE=true
+  - REDMINE_VER=3.4.11 DB=postgresql
   - REDMINE_VER=3.4.0 DB=mysql
   - REDMINE_VER=3.4.0 DB=postgresql
 


### PR DESCRIPTION
This issue is to be sure that we test the latest Redmine version in the 3.4 serie. This PR is only to make sure that Travis still passes.