### PR TITLE
Show actionnable pull requests count in the menu bar

### DIFF
--- a/assets/stylesheets/pulls.css
+++ b/assets/stylesheets/pulls.css
@@ -144,3 +144,11 @@ a.pull__commit:hover {
 #pull_relations table.pulls {
   border: 0;
 }
+
+.tabs .count::before {
+  content: '(';
+}
+
+.tabs .count::after {
+  content: ')';
+}

--- a/init.rb
+++ b/init.rb
@@ -13,8 +13,8 @@ Redmine::Plugin.register :redmine_pulls do
 
   requires_redmine :version_or_higher => '2.3'
 
-  menu :application_menu, :pulls, { :controller => 'pulls', :action => 'index' }, :caption => :label_pulls, :after => :issues
-  menu :project_menu, :pulls, { :controller => 'pulls', :action => 'index' }, :caption => :label_pulls, :after => :issues, :param => :project_id
+  menu :application_menu, :pulls, { :controller => 'pulls', :action => 'index' }, :caption => Proc.new {|project| RedminePulls.menu_caption(project) }, :after => :issues
+  menu :project_menu, :pulls, { :controller => 'pulls', :action => 'index' }, :caption => Proc.new {|project| RedminePulls.menu_caption(project) }, :after => :issues, :param => :project_id
   menu :project_menu, :new_pull, { :controller => 'pulls', :action => 'new' }, :caption => :label_new_pull, :after => :new_issue_sub, :param => :project_id, :parent => :new_object
 
   project_module :pulls do

--- a/lib/redmine_pulls.rb
+++ b/lib/redmine_pulls.rb
@@ -16,3 +16,28 @@ require 'redmine_pulls/patches/routes_helper_patch'
 if Redmine::Plugin.installed? :redmine_git_hosting
   require 'redmine_pulls/patches/adapters/xitolite_adapter_adapter'
 end
+
+module RedminePulls
+  include Redmine::I18n
+
+  class << self
+    def menu_caption(project = nil)
+      caption = l(:label_pulls)
+
+      # Add actionnable count, if greather than zero
+      actionableQuery = Pull.actionable
+
+      if project
+        actionableQuery = actionableQuery.where("#{Pull.table_name}.project_id = ?", project.id)
+      end
+
+      actionableCount = actionableQuery.count
+
+      if actionableCount > 0
+        caption << " <span class='count'>#{actionableCount}</span>"
+      end
+
+      caption.html_safe
+    end
+  end
+end


### PR DESCRIPTION
# Description

Adds a count of actionnable pull requests in the menu bar. A pull request is considered actionnable for a user if:

A. A review has been requested to the user;
B. It is assigned to the user and a concern has been raised;
C. Is assigned to the user and all reviewers have approved.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It was manually tested.

**Test Configuration**:
* Firmware version: ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-darwin18]
* Hardware: macOS 10.14.5 Mojave
* Toolchain: Redmine 3.4.5.stable
* SDK: Rails 4.2.8

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
